### PR TITLE
Fix Flammable Effects After Combats, Make Harmony Patch Declarations Universal

### DIFF
--- a/Features/StatusManager.cs
+++ b/Features/StatusManager.cs
@@ -12,12 +12,6 @@ internal sealed class StatusManager : IKokoroApi.IV2.IStatusLogicApi.IHook
     {
         /* We task Kokoro with the job to register our status into the game */
         Instance.KokoroApi.StatusLogic.RegisterHook(this, 0);
-
-        Instance.Harmony.Patch(
-            original: AccessTools.DeclaredMethod(typeof(AStatus), nameof(AStatus.Begin)),
-            prefix: new HarmonyMethod(GetType(), nameof(AStatus_Begin_Prefix)),
-            postfix: new HarmonyMethod(GetType(), nameof(AStatus_Begin_Postfix))
-        );
     }
 
     private class HarmonyRef

--- a/ModEntry.cs
+++ b/ModEntry.cs
@@ -103,7 +103,12 @@ public sealed class ModEntry : SimpleMod
         // Kokoro is needed to handle statuses
         KokoroApi = helper.ModRegistry.GetApi<IKokoroApi>("Shockah.Kokoro")!.V2;
 
-        Harmony = new Harmony(package.Manifest.UniqueName);
+        Harmony = new Harmony("DragonOfTruth01.ReshiramCCMod");
+
+        // This can be done in place of all Instance.Harmony.Patch() calls in class constructors.
+        // However, this will case your IDE/text editor to think the function is unused (since 
+        // the patch hasn't been given visibility via constructor). This is expected behavior.
+        Harmony.PatchAll();
 
         /* These localizations lists help us organize our mod's text and messages by language.
          * For general use, prefer AnyLocalizations, as that will provide an easier time to potential localization submods that are made for your mod 


### PR DESCRIPTION
This pull request fixes an issue with harmony patching with the ``Ship.ResetAfterCombat()`` harmony prefix (the patch wasn't registered in the constructor). This was also improved by converting the ``Instance.Harmony.Patch()`` invocations in the StatusManager constructor with a more universal ``Harmony.PatchAll()`` invocation in ModEntry.cs, which replaces the need for registration in constructors.