### PR TITLE
Fix Rawst Berry + Flame Orb Bug, Artifact Display Bugs, and Rawst Berry Frequency

### DIFF
--- a/Artifacts/Common/ArtifactFlameOrb.cs
+++ b/Artifacts/Common/ArtifactFlameOrb.cs
@@ -99,6 +99,11 @@ internal sealed class ArtifactFlameOrb : Artifact, IReshiramCCModArtifact
         hasTriggeredThisTurn = false;
     }
 
+    public override void OnCombatEnd(State state)
+    {
+        hasTriggeredThisTurn = false;
+    }
+
     public override Spr GetSprite()
     {
         if (!hasTriggeredThisTurn)

--- a/Artifacts/Common/ArtifactRawstBerry.cs
+++ b/Artifacts/Common/ArtifactRawstBerry.cs
@@ -27,7 +27,7 @@ internal sealed class ArtifactRawstBerry : Artifact, IReshiramCCModArtifact
         });
     }
 
-    bool hasTriggeredThisTurn = false;
+    bool hasTriggeredThisCombat = false;
 
     private class HarmonyRef
     {
@@ -44,7 +44,7 @@ internal sealed class ArtifactRawstBerry : Artifact, IReshiramCCModArtifact
         if (artifact != null)
         {
             __state = new HarmonyRef();
-            __state.triggered = artifact.hasTriggeredThisTurn;
+            __state.triggered = artifact.hasTriggeredThisCombat;
         }
         // If we don't have an instance of the artifact, we dont' care what we assign it
         // (Don't worry, we're not going to use __state in the postfix anyway)
@@ -67,7 +67,7 @@ internal sealed class ArtifactRawstBerry : Artifact, IReshiramCCModArtifact
             if (s.ship.Get(Status.heat) >= s.ship.heatTrigger && !__state.triggered)
             {
                 // First set that we triggered the relic for this turn, to prevent recursion
-                artifact.hasTriggeredThisTurn = true;
+                artifact.hasTriggeredThisCombat = true;
 
                 //Then, apply this relic's effects
                 int heatMod = s.ship.heatTrigger - s.ship.Get(Status.heat) - 1;
@@ -86,14 +86,14 @@ internal sealed class ArtifactRawstBerry : Artifact, IReshiramCCModArtifact
         }
     }
 
-    public override void OnTurnStart(State s, Combat c)
+    public override void OnCombatEnd(State state)
     {
-        hasTriggeredThisTurn = false;
+        hasTriggeredThisCombat = false;
     }
 
     public override Spr GetSprite()
     {
-        if (!hasTriggeredThisTurn)
+        if (!hasTriggeredThisCombat)
         {
             return ModEntry.Instance.ReshiramCCMod_Character_ArtifactRawstBerry.Sprite;
         }


### PR DESCRIPTION
This pull requests fixes three things:
- Fixed the issue with Rawst Berry and Flame Orb interacting weirdly
  - This ended up being as simple as doing a ``>=`` instead of ``>`` for overheat math, and doing a ``QueueImmediate()`` in Rawst Berry code
- Fixed a bug where artifacts that could be disabled, were still disabled between combats (and greyed out)
- Made Rawst Berry correctly work once per combat, instead of once per turn