### PR TITLE
Add Update Checking via Nickel

### DIFF
--- a/nickel.json
+++ b/nickel.json
@@ -10,5 +10,10 @@
       "UniqueName": "Shockah.Kokoro",
       "Version": "2.0.0"
     }
-  ]
+  ],
+  "UpdateChecks": {
+    "NexusMods": {
+      "ID": 78
+    }
+  }
 }


### PR DESCRIPTION
This pull request adds the ability to check for mod updates on the Nexus site.

This was tested by temporarily reducing the version number in nickel.json and checking the mod loader's output on the command line:
<img width="775" height="53" alt="image" src="https://github.com/user-attachments/assets/0d74f848-a88c-4c47-94ad-30732baba24e" />