### PR TITLE
Add Display Name Field in nickel.json

### DIFF
--- a/nickel.json
+++ b/nickel.json
@@ -1,5 +1,6 @@
 {
   "UniqueName": "DragonOfTruth01.ReshiramCCMod",
+  "DisplayName": "Reshiram",
   "Version": "1.0.2",
   "Author": "DragonOfTruth01",
   "Description": "A legendary dragon that represents truth. Its cards utilize heat alongside other debuffs to set enemy ships ablaze.",


### PR DESCRIPTION
This pull request adds a display name in the nickel.json, to better identify the mod in contexts other than those that use the mod's UniqueName.